### PR TITLE
Use streams for Cloudinary to S3 uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.41",
-    "aws-sdk": "^2.208.0",
+    "aws-sdk": "^2.37.0",
     "bluebird": "^3.5.1",
     "cloudinary": "^1.11.0",
-    "node-fetch": "^2.1.2"
+    "node-fetch": "^2.1.2",
+    "s3-upload-stream": "^1.0.7"
   },
   "resolutions": {
     "webpack-sources": "1.0.1",
@@ -70,6 +71,7 @@
     "@types/lodash": "^4.14.104",
     "@types/node": "6",
     "@types/node-fetch": "^1.6.7",
+    "@types/s3-upload-stream": "^1.0.2",
     "@types/webpack": "3",
     "babel-eslint": "^8.2.1",
     "babel-loader": "^8.0.0-beta.2",

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,7 +13,7 @@ provider:
   name: aws
   runtime: nodejs6.10
   stage: ${opt:stage, 'development'}
-  memorySize: 512
+  memorySize: 128
   environment:
     NODE_ENV: ${opt:stage, 'local'}
     CLOUDINARY_CLOUD_NAME: 'hollowverse'

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,13 @@
   version "6.0.103"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.103.tgz#4fddb6c254756e98004039da4e4f4230d1e397ca"
 
+"@types/s3-upload-stream@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/s3-upload-stream/-/s3-upload-stream-1.0.2.tgz#e14e8968b23e0540d0d9a22491a544e58599df16"
+  dependencies:
+    "@types/node" "*"
+    aws-sdk "^2.37.0"
+
 "@types/tapable@^0":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-0.2.5.tgz#2443fc12da514c81346b1a665675559cee21fa75"
@@ -1137,12 +1144,13 @@ autoprefixer@^8.0.0:
     postcss "^6.0.19"
     postcss-value-parser "^3.2.3"
 
-aws-sdk@^2.208.0:
-  version "2.208.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.208.0.tgz#f95e44524cb62c9a6e0ef95270236fc6a62178d6"
+aws-sdk@^2.37.0:
+  version "2.218.1"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.218.1.tgz#b4cf742cc0853bd7c868b388cbf0b4a1ef1abc12"
   dependencies:
     buffer "4.9.1"
-    events "^1.1.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
     jmespath "0.15.0"
     querystring "0.2.0"
     sax "1.2.1"
@@ -2914,7 +2922,7 @@ event-stream@~3.3.0:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-events@1.1.1, events@^1.0.0, events@^1.1.1:
+events@1.1.1, events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -6908,6 +6916,10 @@ rxjs@^5.0.0, rxjs@^5.4.2:
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.7.tgz#afb3d1642b069b2fbf203903d6501d1acb4cda27"
   dependencies:
     symbol-observable "1.0.1"
+
+s3-upload-stream@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/s3-upload-stream/-/s3-upload-stream-1.0.7.tgz#e3f80253141c569f105a62aa50ca9b45760e481d"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"


### PR DESCRIPTION
So we don't have to keep the entire image file in memory.

Also reduce maximum allowed memory since execution is not taking more than 60 MB on average (according to CloudWatch logs).