### PR TITLE
Use IAM conditions instead of ARNs for secrets

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -4,8 +4,6 @@ plugins:
   - serverless-webpack
 
 custom:
-  regionAndAccount: us-east-1:251013100663
-  secretsArnPrefix: arn:aws:secretsmanager:${self:custom.regionAndAccount}:secret:${self:provider.stage}
   webpack:
     webpackConfig: webpack.config.ts
     packager: yarn
@@ -25,8 +23,10 @@ provider:
     - Effect: Allow
       Action:
         - secretsmanager:GetSecretValue
-      Resource:
-        - "${self:custom.secretsArnPrefix}/cloudinary/apiConfig"
+      Conditions:
+        StringEquals:
+          SecretId:
+            - ${self:provider.stage}/cloudinary/apiConfig
     - Effect: Allow
       Action:
         - s3:GetObject*


### PR DESCRIPTION
Use request conditions is more convenient. Also, the secrets ARNs are versioned so the current ARNs won't work anyway.